### PR TITLE
compile-time literals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ include = [ "**/*.rs", "Cargo.toml", "LICENSE-MIT"]
 
 [features]
 default = []
+const_literals = [] # requires rustc >= 1.51 for const generics.
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub const fn is_snake_case(string: &str) -> bool {
     let (len, bytes) = (string.len(), string.as_bytes());
     const fn valid_start(b: u8) -> bool {
         b == b'_' || b'a' <= b && b <= b'z'
-    };
+    }
     const fn is_snake_case_character(c: u8) -> bool {
         b'a' <= c && c <= b'z' || b'0' <= c && c <= b'9' || c == b'_'
     }
@@ -191,7 +191,8 @@ macro_rules! scr_lit {
     ($s:expr) => {{
         struct Valid<const B: bool>;
         let _valid: Valid<true> = Valid::<{ snake_case::is_snake_case($s) }>;
-        unsafe { // this is perfectly safe, wouldnt even compile otherwise.
+        unsafe {
+            // this is perfectly safe, wouldnt even compile otherwise.
             snake_case::from_str_unchecked($s)
         }
     }};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ pub const unsafe fn from_str_unchecked(s: &str) -> SnakeCaseRef {
 /// this will construct a SnakeCafeRef<'static> with compile-time validation for string literals.
 ///
 /// ```
-/// use snake_case::snake_case;
+/// use snake_case::snake_case_lit;
 /// let snake_case = snake_case_lit!("my_little_snake");
 /// // let bad_snake =  snake_case_lit!("Python"); <- this wont compile
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,9 +185,15 @@ pub const unsafe fn from_str_unchecked(s: &str) -> SnakeCaseRef {
     SnakeCaseRef(s)
 }
 #[cfg(feature = "const_literals")]
-/// this will construct a SnakeCafeRef with compile-time validation for string literals.
+/// this will construct a SnakeCafeRef<'static> with compile-time validation for string literals.
+///
+/// ```
+/// use snake_case::snake_case;
+/// let snake_case = snake_case_lit!("my_little_snake");
+/// // let bad_snake =  snake_case_lit!("Python"); <- this wont compile
+/// ```
 #[macro_export]
-macro_rules! scr_lit {
+macro_rules! snake_case_lit {
     ($s:expr) => {{
         struct Valid<const B: bool>;
         let _valid: Valid<true> = Valid::<{ snake_case::is_snake_case($s) }>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,24 @@ impl<'a> SnakeCaseRef<'a> {
     }
 }
 
+#[cfg(feature = "const_literals")]
+/// an unsafe constructor for SnakeCaseRef. caller has to make sure the input is in fact valid.
+pub const unsafe fn from_str_unchecked(s: &str) -> SnakeCaseRef {
+    SnakeCaseRef(s)
+}
+#[cfg(feature = "const_literals")]
+/// this will construct a SnakeCafeRef with compile-time validation for string literals.
+#[macro_export]
+macro_rules! scr_lit {
+    ($s:expr) => {{
+        struct Valid<const B: bool>;
+        let _valid: Valid<true> = Valid::<{ snake_case::is_snake_case($s) }>;
+        unsafe { // this is perfectly safe, wouldnt even compile otherwise.
+            snake_case::from_str_unchecked($s)
+        }
+    }};
+}
+
 impl<'a> TryFrom<&'a str> for SnakeCaseRef<'a> {
     type Error = InvalidSnakeCase;
 


### PR DESCRIPTION
adding a macro to create compile-time validated `SnakeCaseRef<'static>`. feature flagged because requires rust 1.51 for const_generics.